### PR TITLE
Always render score footer and controls

### DIFF
--- a/_jekyll/includes/score/footer.html
+++ b/_jekyll/includes/score/footer.html
@@ -1,4 +1,3 @@
-{% if page.footer %}
 <footer id="score-footer"><!--
 --><button id="score-back" class="score-button" title="Step score pointer -1">
         <svg viewBox="0 0 128 128" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -48,4 +47,3 @@
          </svg>
     </button>{% endif %}
 </footer>
-{% endif %}

--- a/_jekyll/layouts/score-set.html
+++ b/_jekyll/layouts/score-set.html
@@ -22,7 +22,5 @@ layout: compress
         {% include work-list-loop.html layout_contains='movement' filter_by='path' filter_contains=set_path %}
         </ul>
     </main>
-    {% include score/modals.html %}
-    {% include score/scripts.html %}
 </body>
 </html>

--- a/assets/js/_controls.js
+++ b/assets/js/_controls.js
@@ -34,13 +34,13 @@ VS.control = (function() {
         }
     }
 
-    var play = new ScoreControl('score-play', playPause);
+    var playControl = new ScoreControl('score-play', playPause);
 
-    play.setPlay = function() {
+    playControl.setPlay = function() {
         d3.select('g#play').classed('hide', 0);
         d3.select('g#pause').classed('hide', 1);
     };
-    play.setPause = function() {
+    playControl.setPause = function() {
         d3.select('g#play').classed('hide', 1);
         d3.select('g#pause').classed('hide', 0);
     };
@@ -79,15 +79,24 @@ VS.control = (function() {
         event.preventDefault();
     };
 
+    var stopControl = new ScoreControl('score-stop', stop);
+    var backControl = new ScoreControl('score-back', function() { stepPointer(-1); });
+
+    // Set initial control states
+    stopControl.disable();
+    backControl.disable();
+
+    window.addEventListener('keydown', keydownListener, true);
+
     return {
         playCallback: undefined,
         pauseCallback: undefined,
         stopCallback: undefined,
         stepCallback: undefined,
-        play: play,
-        stop: new ScoreControl('score-stop', stop),
+        play: playControl,
+        stop: stopControl,
         fwd: new ScoreControl('score-fwd', function() { stepPointer(1); }),
-        back: new ScoreControl('score-back', function() { stepPointer(-1); }),
+        back: backControl,
         pointer: new ScoreControl('score-pointer', VS.score.pause),
         updateStepButtons: function() {
             if (VS.score.pointer === 0) {
@@ -105,7 +114,3 @@ VS.control = (function() {
     };
 
 })();
-
-VS.control.back.disable();
-VS.control.stop.disable();
-window.addEventListener('keydown', VS.control.keydownListener, true);

--- a/assets/js/_controls.js
+++ b/assets/js/_controls.js
@@ -1,114 +1,111 @@
-if (VS.layout.footer) {
+VS.control = (function() {
 
-    VS.control = (function() {
+    function ScoreControl(id, fn) {
+        this.element = document.getElementById(id);
+        this.element.onclick = fn;
+    }
+    ScoreControl.prototype.enable = function() {
+        this.element.disabled = false;
+    };
+    ScoreControl.prototype.disable = function() {
+        this.element.disabled = true;
+    };
 
-        function ScoreControl(id, fn) {
-            this.element = document.getElementById(id);
-            this.element.onclick = fn;
+    function playPause() {
+        if (!VS.score.playing) {
+            VS.score.play();
+            VS.cb(VS.control.playCallback);
+        } else {
+            VS.score.pause();
+            VS.cb(VS.control.pauseCallback);
         }
-        ScoreControl.prototype.enable = function() {
-            this.element.disabled = false;
-        };
-        ScoreControl.prototype.disable = function() {
-            this.element.disabled = true;
-        };
+    }
 
-        function playPause() {
-            if (!VS.score.playing) {
-                VS.score.play();
-                VS.cb(VS.control.playCallback);
+    function stop() {
+        VS.score.stop();
+        VS.cb(VS.control.stopCallback);
+    }
+
+    function stepPointer(steps) {
+        if (!VS.score.playing) { // don't allow skip while playing, for now
+            VS.score.updatePointer(VS.clamp(VS.score.pointer + steps, 0, VS.score.getLength() - 1));
+            VS.control.updateStepButtons();
+            VS.cb(VS.control.stepCallback);
+        }
+    }
+
+    var play = new ScoreControl('score-play', playPause);
+
+    play.setPlay = function() {
+        d3.select('g#play').classed('hide', 0);
+        d3.select('g#pause').classed('hide', 1);
+    };
+    play.setPause = function() {
+        d3.select('g#play').classed('hide', 1);
+        d3.select('g#pause').classed('hide', 0);
+    };
+
+    var keydownListener = function(event) {
+        if (event.defaultPrevented || event.metaKey) {
+            return;
+        }
+
+        var keyPressed = event.key || event.keyCode;
+
+        switch (keyPressed) {
+        case ' ':
+        case 32:
+            playPause();
+            break;
+        case 'ArrowLeft':
+        case 37:
+            stepPointer(-1);
+            break;
+        case 'ArrowRight':
+        case 39:
+            stepPointer(1);
+            break;
+        case 'Escape':
+        case 27:
+            stop();
+            break;
+        // case "/":
+        // case 191:
+        //     document.getElementById("score-pointer").focus();
+        //     break;
+        default:
+            return;
+        }
+        event.preventDefault();
+    };
+
+    return {
+        playCallback: undefined,
+        pauseCallback: undefined,
+        stopCallback: undefined,
+        stepCallback: undefined,
+        play: play,
+        stop: new ScoreControl('score-stop', stop),
+        fwd: new ScoreControl('score-fwd', function() { stepPointer(1); }),
+        back: new ScoreControl('score-back', function() { stepPointer(-1); }),
+        pointer: new ScoreControl('score-pointer', VS.score.pause),
+        updateStepButtons: function() {
+            if (VS.score.pointer === 0) {
+                this.back.disable();
+                this.fwd.enable();
+            } else if (VS.score.pointer === (VS.score.getLength() - 1)) {
+                this.back.enable();
+                this.fwd.disable();
             } else {
-                VS.score.pause();
-                VS.cb(VS.control.pauseCallback);
+                this.back.enable();
+                this.fwd.enable();
             }
-        }
+        },
+        keydownListener: keydownListener
+    };
 
-        function stop() {
-            VS.score.stop();
-            VS.cb(VS.control.stopCallback);
-        }
+})();
 
-        function stepPointer(steps) {
-            if (!VS.score.playing) { // don't allow skip while playing, for now
-                VS.score.updatePointer(VS.clamp(VS.score.pointer + steps, 0, VS.score.getLength() - 1));
-                VS.control.updateStepButtons();
-                VS.cb(VS.control.stepCallback);
-            }
-        }
-
-        var play = new ScoreControl('score-play', playPause);
-
-        play.setPlay = function() {
-            d3.select('g#play').classed('hide', 0);
-            d3.select('g#pause').classed('hide', 1);
-        };
-        play.setPause = function() {
-            d3.select('g#play').classed('hide', 1);
-            d3.select('g#pause').classed('hide', 0);
-        };
-
-        var keydownListener = function(event) {
-            if (event.defaultPrevented || event.metaKey) {
-                return;
-            }
-
-            var keyPressed = event.key || event.keyCode;
-
-            switch (keyPressed) {
-            case ' ':
-            case 32:
-                playPause();
-                break;
-            case 'ArrowLeft':
-            case 37:
-                stepPointer(-1);
-                break;
-            case 'ArrowRight':
-            case 39:
-                stepPointer(1);
-                break;
-            case 'Escape':
-            case 27:
-                stop();
-                break;
-            // case "/":
-            // case 191:
-            //     document.getElementById("score-pointer").focus();
-            //     break;
-            default:
-                return;
-            }
-            event.preventDefault();
-        };
-
-        return {
-            playCallback: undefined,
-            pauseCallback: undefined,
-            stopCallback: undefined,
-            stepCallback: undefined,
-            play: play,
-            stop: new ScoreControl('score-stop', stop),
-            fwd: new ScoreControl('score-fwd', function() { stepPointer(1); }),
-            back: new ScoreControl('score-back', function() { stepPointer(-1); }),
-            pointer: new ScoreControl('score-pointer', VS.score.pause),
-            updateStepButtons: function() {
-                if (VS.score.pointer === 0) {
-                    this.back.disable();
-                    this.fwd.enable();
-                } else if (VS.score.pointer === (VS.score.getLength() - 1)) {
-                    this.back.enable();
-                    this.fwd.disable();
-                } else {
-                    this.back.enable();
-                    this.fwd.enable();
-                }
-            },
-            keydownListener: keydownListener
-        };
-
-    })();
-
-    VS.control.back.disable();
-    VS.control.stop.disable();
-    window.addEventListener('keydown', VS.control.keydownListener, true);
-}
+VS.control.back.disable();
+VS.control.stop.disable();
+window.addEventListener('keydown', VS.control.keydownListener, true);

--- a/assets/js/_layout.js
+++ b/assets/js/_layout.js
@@ -26,7 +26,8 @@ VS.layout = (function() {
     addLayoutInteraction(layout.header);
     addLayoutInteraction(layout.footer);
 
+    // Hide layout when interacting with score
+    document.getElementsByTagName('main')[0].onclick = layout.hide;
+
     return layout;
 })();
-
-document.getElementsByTagName('main')[0].onclick = VS.layout.hide;

--- a/assets/js/_layout.js
+++ b/assets/js/_layout.js
@@ -6,10 +6,7 @@ VS.layout = (function() {
 
     function setClass(c) {
         layout.header.className = c;
-
-        if (layout.footer) {
-            layout.footer.className = c;
-        }
+        layout.footer.className = c;
     }
 
     layout.show = function() {
@@ -27,10 +24,7 @@ VS.layout = (function() {
     }
 
     addLayoutInteraction(layout.header);
-
-    if (layout.footer) {
-        addLayoutInteraction(layout.footer);
-    }
+    addLayoutInteraction(layout.footer);
 
     return layout;
 })();

--- a/assets/js/_modals.js
+++ b/assets/js/_modals.js
@@ -7,12 +7,10 @@ VS.enableModal = function(modalId, openId, closeId) {
     function openModal() {
         overlay.style.display = 'block';
         modal.style.display = 'block';
-        VS.layout.show();
 
-        if (VS.layout.footer) {
-            VS.score.pause();
-            window.removeEventListener('keydown', VS.control.keydownListener, true);
-        }
+        VS.layout.show();
+        VS.score.pause();
+        window.removeEventListener('keydown', VS.control.keydownListener, true);
 
         closeTrigger.addEventListener('click', closeModal, true);
         window.addEventListener('click', clickListener, true);
@@ -24,9 +22,7 @@ VS.enableModal = function(modalId, openId, closeId) {
         modal.style.display = 'none';
         VS.layout.hide();
 
-        if (VS.layout.footer) {
-            window.addEventListener('keydown', VS.control.keydownListener, true);
-        }
+        window.addEventListener('keydown', VS.control.keydownListener, true);
 
         closeTrigger.removeEventListener('click', closeModal, true);
         window.removeEventListener('click', clickListener, true);

--- a/assets/js/vs-modules/websockets.js
+++ b/assets/js/vs-modules/websockets.js
@@ -18,20 +18,18 @@ VS.WebSocket = (function() {
     log('Not connected');
 
     function addControlCallbacks() {
-        if (VS.control) {
-            VS.control.playCallback = function() {
-                VS.WebSocket.send(['vs', 'play', VS.score.pointer]);
-            };
-            VS.control.pauseCallback = function() {
-                VS.WebSocket.send(['vs', 'pause', VS.score.pointer]);
-            };
-            VS.control.stopCallback = function() {
-                VS.WebSocket.send(['vs', 'stop']);
-            };
-            VS.control.stepCallback = function() {
-                VS.WebSocket.send(['vs', 'step', VS.score.pointer]);
-            };
-        }
+        VS.control.playCallback = function() {
+            VS.WebSocket.send(['vs', 'play', VS.score.pointer]);
+        };
+        VS.control.pauseCallback = function() {
+            VS.WebSocket.send(['vs', 'pause', VS.score.pointer]);
+        };
+        VS.control.stopCallback = function() {
+            VS.WebSocket.send(['vs', 'stop']);
+        };
+        VS.control.stepCallback = function() {
+            VS.WebSocket.send(['vs', 'step', VS.score.pointer]);
+        };
     }
 
     ws.messageCallback = undefined;

--- a/scores/3d-object/index.html
+++ b/scores/3d-object/index.html
@@ -1,7 +1,7 @@
 ---
 layout: score
 title: 3D object
-status: test
+status: unlisted
 ---
 <!-- <h3>Controls: performer angle</h3>
 <div class="position-controls">

--- a/scores/Textural-Messages/index.html
+++ b/scores/Textural-Messages/index.html
@@ -1,7 +1,7 @@
 ---
 layout: score
 title: Textural Messages
-status: test
+status: unlisted
 #settings_file: _settings.html
 vs_modules: [globject, xByDuration, trichords, pitchClass, settings.radio]
 ---

--- a/scores/Textural-Messages/index.html
+++ b/scores/Textural-Messages/index.html
@@ -2,7 +2,6 @@
 layout: score
 title: Textural Messages
 status: test
-footer: true
 #settings_file: _settings.html
 vs_modules: [globject, xByDuration, trichords, pitchClass, settings.radio]
 ---

--- a/scores/adsr/index.html
+++ b/scores/adsr/index.html
@@ -11,5 +11,4 @@ settings_file: _settings.md
 vs_modules: [cue-blink, xByDuration, dictionary.bravura, websockets]
 status: published
 formats: [score, parts]
-footer: true
 ---

--- a/scores/decision-tree/cells/_controls.js
+++ b/scores/decision-tree/cells/_controls.js
@@ -1,15 +1,10 @@
 /**
- * Score
+ * Score callbacks
+ * Choices should be cleared so new choices can be loaded and selected on play
  */
+VS.score.pauseCallback = clearChoices;
 VS.score.stopCallback = clearChoices;
-
-VS.score.stepCallback = function() {
-    if (VS.score.pointer === 0) {
-        clearChoices();
-    } else if (VS.score.pointer < VS.score.getLength() - 1) {
-        updateChoices();
-    }
-};
+VS.score.stepCallback = clearChoices;
 
 /**
  * Keyboard

--- a/scores/decision-tree/cells/_controls.js
+++ b/scores/decision-tree/cells/_controls.js
@@ -4,7 +4,6 @@
  */
 VS.score.pauseCallback = clearChoices;
 VS.score.stopCallback = clearChoices;
-VS.score.stepCallback = clearChoices;
 
 /**
  * Keyboard

--- a/scores/decision-tree/cells/index.html
+++ b/scores/decision-tree/cells/index.html
@@ -11,7 +11,6 @@ info: >
         Play the phrase in the selected box using the pitch classes shown outside the box.
         The quarter rest is used generically to indicate the player should rest.
     </p>
-footer: true
 settings: >
     Display pitch classes as:
     <div style="margin: 1em 0;">

--- a/scores/decision-tree/cells/index.js
+++ b/scores/decision-tree/cells/index.js
@@ -20,10 +20,12 @@ var score = {
     intervalSpread: 5000,
     // TODO increase over time/score pointer?
     // TODO scale according to number of choices per param?
-    weightScale: 5
+    weightScale: 5,
+    transitionTime: 300
 };
 
 var debug = +VS.getQueryString('debug') === 1;
+var debugChoices;
 
 var layout = {
     margin: {}
@@ -71,7 +73,7 @@ function transformCell(selection, position, selected) {
         translateFn = position === 'top' ? translateTopCell : translateBottomCell;
     }
 
-    selection.transition().duration(300)
+    selection.transition().duration(score.transitionTime)
         .style('opacity', opacity)
         .attr('transform', translateFn);
         // .transition()
@@ -158,11 +160,13 @@ function selectCell(position) {
     }
 }
 
-function debugChoices() {
-    var el = document.getElementsByClassName('debug')[0];
+if (debug) {
+    debugChoices = function () {
+        var el = document.getElementsByClassName('debug')[0];
 
-    el.innerHTML = 'weight: ' + score.partWeight + '<br />';
-    el.innerHTML += params.getWeights().split('\n').join('<br />');
+        el.innerHTML = 'weight: ' + score.partWeight + '<br />';
+        el.innerHTML += params.getWeights().split('\n').join('<br />');
+    }
 }
 
 /**
@@ -242,16 +246,19 @@ score.bottomGroup = score.wrapper.append('g')
         selectCell('bottom');
     });
 
+function clearGroup(position) {
+    var group = position + 'Group';
+
+    score[group].call(transformCell, position);
+    score[group].selectAll('.bravura').text('');
+    score[group].select('.pitch-classes').text('{}');
+}
+
 function clearChoices() {
     // TODO also clear choice weights
 
-    score.topGroup.call(transformCell, 'top');
-    score.topGroup.selectAll('.bravura').text('');
-    score.topGroup.select('.pitch-classes').text('{}');
-
-    score.bottomGroup.call(transformCell, 'bottom');
-    score.bottomGroup.selectAll('.bravura').text('');
-    score.bottomGroup.select('.pitch-classes').text('{}');
+    clearGroup('top');
+    clearGroup('bottom');
 }
 
 clearChoices();

--- a/scores/dirge-march/index.html
+++ b/scores/dirge-march/index.html
@@ -5,7 +5,6 @@ instrumentation: any ensemble (3+ pitched, 2+ percussive)
 duration: 5&prime;39&Prime;
 status: wip
 formats: score
-footer: true
 info_file: _info.md
 settings: >
     Display pitch classes as:

--- a/scores/glob/_controls.js
+++ b/scores/glob/_controls.js
@@ -1,3 +1,8 @@
 VS.control.stepCallback = VS.score.stopCallback = function() {
-    update(transitionTime.short, score[VS.score.pointer]);
+    var pointer = VS.score.pointer;
+    var fn = VS.score.funcAt(pointer);
+
+    if (typeof fn === 'function') {
+        update(transitionTime.short, score[VS.score.pointer]);
+    }
 };

--- a/scores/glob/_glob.js
+++ b/scores/glob/_glob.js
@@ -73,6 +73,7 @@ Glob.prototype.move = function(dur, data) {
     // update
     globules
         .transition(t)
+        .style('opacity', 1)
         .attr('transform', transform);
 
     // enter

--- a/scores/glob/index.html
+++ b/scores/glob/index.html
@@ -4,7 +4,6 @@ title: glob
 instrumentation: any ensemble
 status: wip
 formats: score
-footer: true
 settings_file: _settings.md
 vs_modules: [dictionary.bravura, pitchClass, settings.radio, settings.pitch-classes]
 ---

--- a/scores/globject/index.html
+++ b/scores/globject/index.html
@@ -1,6 +1,6 @@
 ---
 layout: score
 title: globject
-status: test
+status: unlisted
 vs_modules: [globject, dictionary.bravura, xByDuration, trichords, pitchClass]
 ---

--- a/scores/globject/index.html
+++ b/scores/globject/index.html
@@ -2,6 +2,5 @@
 layout: score
 title: globject
 status: test
-footer: true
 vs_modules: [globject, dictionary.bravura, xByDuration, trichords, pitchClass]
 ---

--- a/scores/storyboard/cards/index.html
+++ b/scores/storyboard/cards/index.html
@@ -2,7 +2,6 @@
 layout: movement
 title: cards
 status: wip
-footer: true
 settings: >
     Display pitch classes as:
     <div style="margin: 1em 0;">

--- a/scores/storyboard/prelude/index.html
+++ b/scores/storyboard/prelude/index.html
@@ -2,7 +2,6 @@
 layout: movement
 title: prelude
 status: wip
-footer: true
 info_file: _info.md
 settings_file: _settings.md
 vs_modules: [dictionary.bravura, pitchClass, settings.radio, settings.pitch-classes, line-cloud, cue-blink]

--- a/scores/time-control/index.html
+++ b/scores/time-control/index.html
@@ -12,7 +12,7 @@ info: >
 ---
 <p id="events"></p>
 
-{% comment %}<div class="ws">
+{% comment %}<div class="websockets">
     <h3>WebSockets</h3>
     {% unless jekyll.environment == "offline" %}
     <p>Only available in local environment.</p>

--- a/scores/time-control/index.html
+++ b/scores/time-control/index.html
@@ -2,7 +2,6 @@
 layout: score
 title: timing controls
 status: test
-footer: true
 info: >
     <h3>Playground for event timing<!--, including WebSocket control--></h3>
     <!--<p>

--- a/scores/time-control/styles.scss
+++ b/scores/time-control/styles.scss
@@ -1,11 +1,12 @@
 ---
 ---
-$t-time: 1s;
+$t-time: 300ms;
 
 main {
 	padding: 8px;
 }
-.event-span {
+
+#events span {
 	font-family: Courier;
 	display: inline-block;
 	padding: 0.5em;
@@ -13,20 +14,23 @@ main {
 	border: 2px solid #eee;
 	border-radius: 20px;
 	transition: border-radius $t-time, border-color $t-time;
+
+	&.green {
+		border-color: rgba(0, 255, 0, 0.75);
+		transition: border-color $t-time;
+	}
+
+	&.blue {
+		border-color: rgba(0, 0, 255, 0.75);
+		transition: border-color $t-time;
+	}
+
 	&.box {
 		border-radius: 0px;
 		transition: border-radius $t-time;
 	}
 }
-.active {
-	border-color: rgba(0, 255, 0, 0.75);
-	transition: border-color $t-time;
-}
-.other {
-	border-color: rgba(0, 0, 255, 0.75);
-	transition: border-color $t-time;
-}
 
-.ws, .ws h3 {
+.websockets, .websockets h3 {
 	font-family: Courier;
 }

--- a/scores/topographies-ii/walk-reveal/index.html
+++ b/scores/topographies-ii/walk-reveal/index.html
@@ -2,7 +2,6 @@
 layout: movement
 title: walk reveal
 status: wip
-footer: true
 vs_modules: dictionary.bravura
 info: >
     <p>

--- a/scores/topographies-ii/walk-reveal/index.js
+++ b/scores/topographies-ii/walk-reveal/index.js
@@ -280,7 +280,7 @@ function randDuration() {
 /**
  * Reveal a starting point
  */
- (function() {
+(function() {
     var extremaIndices = [];
 
     for (var i = 0; i < topoData.length; i++) {

--- a/scores/topographies-ii/walk-reveal/index.js
+++ b/scores/topographies-ii/walk-reveal/index.js
@@ -22,6 +22,7 @@ var main = d3.select('.main'),
     },
     revealFactor = 62,
     nearbyRevealFactor = 38,
+    transitionTime = 600,
     nEvents = 100;
 
 var layout = {
@@ -141,7 +142,7 @@ function revealSymbols(selection, dur) {
         });
 }
 
-function moveWalker() {
+function moveWalker(duration) {
     var c = indexToCoordinates(walker.index);
     var notWalked = [];
     var available = [];
@@ -211,10 +212,10 @@ function moveWalker() {
     topoData[walker.index].walked = true;
     topoData[walker.index].revealed = revealFactor;
 
-    revealNearby();
+    revealNearby(duration);
 }
 
-function revealNearby() {
+function revealNearby(duration) {
     // Chance nearby symbols will be revealed
     var chance = 0.2;
 
@@ -247,13 +248,21 @@ function revealNearby() {
     }
 
     // Update map
-    topo.selectAll('text').call(revealSymbols, 600);
+    topo.selectAll('text').call(revealSymbols, duration || transitionTime);
+}
+
+function forgetAll(duration) {
+    topo.selectAll('text')
+    .each(function(d) {
+        d.revealed = 0;
+    })
+    .call(revealSymbols, duration || transitionTime);
 }
 
 /**
  * Populate score
  */
-VS.score.preroll = 1000;
+VS.score.preroll = transitionTime;
 
 var addEvent = (function() {
     var time = 0;
@@ -267,10 +276,11 @@ var addEvent = (function() {
 function randDuration() {
     return 1200; // 600 + (Math.random() * 600);
 }
+
 /**
  * Reveal a starting point
  */
-addEvent(function() {
+ (function() {
     var extremaIndices = [];
 
     for (var i = 0; i < topoData.length; i++) {
@@ -285,44 +295,69 @@ addEvent(function() {
     topoData[startIndex].revealed = revealFactor;
     topoData[walker.index].walker = true;
     topoData[walker.index].walked = true;
+}());
 
-    topo.selectAll('text').call(revealSymbols, 600);
-}, randDuration());
 
+/**
+ * Fade instructions in and out
+ */
+
+ // Start with instructions off
+ addEvent(function(duration) {
+     toggleInstructions(duration, false);
+ }, 0);
+
+addEvent(function(duration) {
+    toggleInstructions(duration, true);
+}, 3600);
+
+addEvent(function(duration) {
+    toggleInstructions(duration, false);
+    // Fade out symbols if stepping back
+    forgetAll(duration);
+}, 3600);
+
+// Add walk events
 for (var i = 0; i < nEvents; i++) {
     addEvent(moveWalker, randDuration());
 }
 
-// final events
-addEvent(function() {
-    topo.selectAll('text')
-        .each(function(d) {
-            d.revealed = 0;
-        })
-        .call(revealSymbols, 6000);
+// Add final events
+addEvent(function(duration) {
+    forgetAll(duration || 6000);
 }, 6000);
 
 addEvent(undefined, 0);
 
 /**
- *
+ * Instructions
  */
 var instructions = wrapper.append('text')
     .attr('class', 'instructions')
     .attr('text-anchor', 'middle')
     .attr('y', 220)
-    .attr('opacity', 1)
+    .attr('opacity', 0)
     .text('explore the unknown, try to remember the past');
 
-VS.score.playCallback = function() {
-    instructions.transition().duration(600)
-        .attr('opacity', 0);
+function toggleInstructions(duration, toggle) {
+    var opacity = toggle ? 1 : 0;
+    instructions.transition().duration(duration || transitionTime)
+        .attr('opacity', opacity);
+}
+
+/**
+ * Controls
+ */
+VS.control.stepCallback = function() {
+    var pointer = VS.score.pointer;
+    var fn = VS.score.funcAt(pointer);
+
+    if (typeof fn === 'function') {
+        fn(150);
+    }
 };
 
-VS.score.stopCallback = function() {
-    instructions.transition().duration(600)
-        .attr('opacity', 1);
-};
+VS.score.stopCallback = forgetAll;
 
 /**
  * Resize

--- a/scores/trashfire/index.html
+++ b/scores/trashfire/index.html
@@ -4,5 +4,4 @@ title: trashfire
 instrumentation: any ensemble
 status: wip
 formats: score
-footer: true
 ---

--- a/scores/tutorial/index.html
+++ b/scores/tutorial/index.html
@@ -2,7 +2,6 @@
 layout: score
 title: tutorial
 status: test
-footer: true
 info: >
     Close the info modal by clicking away, clicking the close button in the top right, or by pressing the escape key.
 settings: >

--- a/scores/tutorial/index.js
+++ b/scores/tutorial/index.js
@@ -114,7 +114,7 @@ addEvent(function() {
 /**
  *
  */
-VS.score.stepCallback = function() {
+VS.control.stepCallback = function() {
     VS.score.funcAt(VS.score.pointer)();
 };
 


### PR DESCRIPTION
Closes #36, with the intention that each score should have timing controls. The aim is to simplify the logic—if the need arises to render a score without the core controls it can be handled at that time.

- [x]  always include footer for scores
- [x] remove unused partials from set layout
- [x] refactor scores without proper step control callbacks, with the exception of _trashfire_
- [x] clean up layout and control initialization
