### PR TITLE
Use hooks interface (formerly callbacks) in score, control, websockets

### DIFF
--- a/assets/js/_controls.js
+++ b/assets/js/_controls.js
@@ -30,7 +30,11 @@ VS.control = (function() {
         if (!VS.score.playing) { // don't allow skip while playing, for now
             VS.score.updatePointer(VS.clamp(VS.score.pointer + steps, 0, VS.score.getLength() - 1));
             VS.control.updateStepButtons();
-            VS.cb(VS.control.stepCallback);
+            // VS.cb(VS.control.stepCallback);
+
+            for (var i = 0; i < VS.control.stepCallback.length; i++) {
+                VS.control.stepCallback[i]();
+            }
         }
     }
 
@@ -92,7 +96,7 @@ VS.control = (function() {
         playCallback: undefined,
         pauseCallback: undefined,
         stopCallback: undefined,
-        stepCallback: undefined,
+        stepCallback: [],
         play: playControl,
         stop: stopControl,
         fwd: new ScoreControl('score-fwd', function() { stepPointer(1); }),

--- a/assets/js/_controls.js
+++ b/assets/js/_controls.js
@@ -30,11 +30,7 @@ VS.control = (function() {
         if (!VS.score.playing) { // don't allow skip while playing, for now
             VS.score.updatePointer(VS.clamp(VS.score.pointer + steps, 0, VS.score.getLength() - 1));
             VS.control.updateStepButtons();
-            // VS.cb(VS.control.stepCallback);
-
-            for (var i = 0; i < VS.control.stepCallback.length; i++) {
-                VS.control.stepCallback[i]();
-            }
+            hooks.trigger('step');
         }
     }
 
@@ -90,6 +86,8 @@ VS.control = (function() {
     stopControl.disable();
     backControl.disable();
 
+    var hooks = VS.createHooks(['play', 'pause', 'stop', 'step']);
+
     window.addEventListener('keydown', keydownListener, true);
 
     return {
@@ -101,6 +99,7 @@ VS.control = (function() {
         stop: stopControl,
         fwd: new ScoreControl('score-fwd', function() { stepPointer(1); }),
         back: backControl,
+        hooks: hooks,
         pointer: new ScoreControl('score-pointer', VS.score.pause),
         updateStepButtons: function() {
             if (VS.score.pointer === 0) {

--- a/assets/js/_controls.js
+++ b/assets/js/_controls.js
@@ -14,16 +14,16 @@ VS.control = (function() {
     function playPause() {
         if (!VS.score.playing) {
             VS.score.play();
-            VS.cb(VS.control.playCallback);
+            hooks.trigger('play');
         } else {
             VS.score.pause();
-            VS.cb(VS.control.pauseCallback);
+            hooks.trigger('pause');
         }
     }
 
     function stop() {
         VS.score.stop();
-        VS.cb(VS.control.stopCallback);
+        hooks.trigger('stop');
     }
 
     function stepPointer(steps) {
@@ -91,10 +91,6 @@ VS.control = (function() {
     window.addEventListener('keydown', keydownListener, true);
 
     return {
-        playCallback: undefined,
-        pauseCallback: undefined,
-        stopCallback: undefined,
-        stepCallback: [],
         play: playControl,
         stop: stopControl,
         fwd: new ScoreControl('score-fwd', function() { stepPointer(1); }),

--- a/assets/js/_hooks.js
+++ b/assets/js/_hooks.js
@@ -1,0 +1,46 @@
+/**
+ * Factory function to add hooks to internal methods
+ * Currently no method to remove at this time as
+ * hooks are not dynamically added/removed
+ * @param {...string} : keys of hooks
+ */
+VS.createHooks = function() {
+
+    var hooks = {};
+
+    /**
+     * Initialize dictionary
+     */
+    var dictionary = {};
+
+    for (var i = 0; i < arguments.length; i++) {
+        dictionary[arguments[i]] = [];
+    }
+
+    /**
+     * Add hook
+     * @param {string} hook : key of hook to add to
+     * @param {function} fn : function to add to hook
+     */
+    hooks.add = function(hook, fn) {
+        if (dictionary[hook]) {
+            dictionary[hook].push(fn);
+        } else {
+            throw new Error('[hooks#add] ' + hook + ' is not a registered hook');
+        }
+    };
+
+    /**
+     * Call all functions for a given hook
+     * @param {string} hook : key of hook to trigger
+     */
+    hooks.trigger = function(hook) {
+        var fns = dictionary[hook];
+
+        for (var i = 0; i < fns.length; i++) {
+            fns[i]();
+        }
+    };
+
+    return Object.freeze(hooks);
+};

--- a/assets/js/_hooks.js
+++ b/assets/js/_hooks.js
@@ -2,9 +2,9 @@
  * Factory function to add hooks to internal methods
  * Currently no method to remove at this time as
  * hooks are not dynamically added/removed
- * @param {...string} : keys of hooks
+ * @param {array} keys : keys of hooks
  */
-VS.createHooks = function() {
+VS.createHooks = function(keys) {
 
     var hooks = {};
 
@@ -13,8 +13,8 @@ VS.createHooks = function() {
      */
     var dictionary = {};
 
-    for (var i = 0; i < arguments.length; i++) {
-        dictionary[arguments[i]] = [];
+    for (var i = 0; i < keys.length; i++) {
+        dictionary[keys[i]] = [];
     }
 
     /**

--- a/assets/js/_score.js
+++ b/assets/js/_score.js
@@ -7,10 +7,12 @@ VS.score = (function() {
         }
     }
 
+    var hooks = VS.createHooks(['play', 'pause', 'stop', 'step']);
+
     function updatePointer(index) {
         VS.score.pointer = index;
         VS.control.pointer.element.value = index;
-        VS.cb(VS.score.stepCallback);
+        hooks.trigger('step');
     }
 
     function playEvent(index) {
@@ -52,11 +54,7 @@ VS.score = (function() {
                 clearTimeout(t);
             });
         },
-
-        playCallback: undefined,
-        pauseCallback: undefined,
-        stopCallback: undefined,
-        stepCallback: undefined,
+        hooks: hooks,
         play: function() {
             VS.score.playing = true;
             VS.control.play.setPause();
@@ -65,7 +63,7 @@ VS.score = (function() {
             VS.control.fwd.disable();
             schedule(VS.score.preroll, playEvent, VS.score.pointer);
             VS.layout.hide();
-            VS.cb(VS.score.playCallback);
+            hooks.trigger('play');
         },
         pause: function() {
             VS.score.playing = false;
@@ -73,7 +71,7 @@ VS.score = (function() {
             VS.score.clearAllTimeouts();
             VS.control.updateStepButtons();
             VS.layout.show();
-            VS.cb(VS.score.pauseCallback);
+            hooks.trigger('pause');
         },
         stop: function() {
             VS.score.playing = false;
@@ -84,7 +82,7 @@ VS.score = (function() {
             VS.score.clearAllTimeouts();
             VS.control.updateStepButtons();
             VS.layout.show();
-            VS.cb(VS.score.stopCallback);
+            hooks.trigger('stop');
         },
         schedule: schedule,
         updatePointer: updatePointer

--- a/assets/js/_tests/hooks.js
+++ b/assets/js/_tests/hooks.js
@@ -1,0 +1,30 @@
+const path = require('path')
+const { test, setupDOM } = require(path.resolve('.', 'bin/js/tape-setup'))
+setupDOM('_site/scores/tutorial/index.html')
+
+const VS = require(path.resolve('.', '_site/assets/js/vectorscores.js'))
+
+test('VS#hooks', t => {
+    const hooks = new VS.createHooks('play')
+
+    const expected = {
+        a: 2,
+        b: 4,
+        c: 6
+    }
+    let actual = {}
+
+    hooks.add('play', () => { actual.a = 2 })
+    hooks.add('play', () => { actual.b = 4 })
+    hooks.add('play', () => { actual.c = 6 })
+
+    hooks.trigger('play')
+
+    t.deepEqual(actual, expected, 'should execute all registered callbacks')
+
+    t.throws(() => {
+        hooks.add('test', () => {})
+    }, 'should throw an error when adding an unregistered hook')
+
+    t.end()
+})

--- a/assets/js/_tests/hooks.js
+++ b/assets/js/_tests/hooks.js
@@ -5,7 +5,7 @@ setupDOM('_site/scores/tutorial/index.html')
 const VS = require(path.resolve('.', '_site/assets/js/vectorscores.js'))
 
 test('VS#hooks', t => {
-    const hooks = new VS.createHooks('play')
+    const hooks = new VS.createHooks(['play'])
 
     const expected = {
         a: 2,

--- a/assets/js/vectorscores.js
+++ b/assets/js/vectorscores.js
@@ -6,6 +6,7 @@ var VS = {};
 
 {% include_relative _helpers.util.js %}
 {% include_relative _helpers.math.js %}
+{% include_relative _hooks.js %}
 {% include_relative _layout.js %}
 {% include_relative _score.js %}
 {% include_relative _controls.js %}

--- a/assets/js/vs-modules/websockets.js
+++ b/assets/js/vs-modules/websockets.js
@@ -18,15 +18,15 @@ VS.WebSocket = (function() {
     log('Not connected');
 
     function addControlCallbacks() {
-        VS.control.playCallback = function() {
+        VS.control.hooks.add('play', function() {
             VS.WebSocket.send(['vs', 'play', VS.score.pointer]);
-        };
-        VS.control.pauseCallback = function() {
+        });
+        VS.control.hooks.add('pause', function() {
             VS.WebSocket.send(['vs', 'pause', VS.score.pointer]);
-        };
-        VS.control.stopCallback = function() {
+        });
+        VS.control.hooks.add('stop', function() {
             VS.WebSocket.send(['vs', 'stop']);
-        };
+        });
         VS.control.hooks.add('step', function() {
             VS.WebSocket.send(['vs', 'step', VS.score.pointer]);
         });

--- a/assets/js/vs-modules/websockets.js
+++ b/assets/js/vs-modules/websockets.js
@@ -27,7 +27,7 @@ VS.WebSocket = (function() {
         VS.control.stopCallback = function() {
             VS.WebSocket.send(['vs', 'stop']);
         };
-        VS.control.stepCallback.push(function() {
+        VS.control.hooks.add('step', function() {
             VS.WebSocket.send(['vs', 'step', VS.score.pointer]);
         });
     }

--- a/assets/js/vs-modules/websockets.js
+++ b/assets/js/vs-modules/websockets.js
@@ -27,9 +27,9 @@ VS.WebSocket = (function() {
         VS.control.stopCallback = function() {
             VS.WebSocket.send(['vs', 'stop']);
         };
-        VS.control.stepCallback = function() {
+        VS.control.stepCallback.push(function() {
             VS.WebSocket.send(['vs', 'step', VS.score.pointer]);
-        };
+        });
     }
 
     ws.messageCallback = undefined;

--- a/scores/adsr/index.js
+++ b/scores/adsr/index.js
@@ -462,7 +462,7 @@ function scrollCallback() {
 }
 VS.score.pauseCallback = scrollCallback;
 VS.score.stopCallback = scrollCallback;
-VS.score.stepCallback = scrollCallback;
+VS.control.stepCallback.push(scrollCallback);
 
 function resize() {
     // TODO pause score if playing

--- a/scores/adsr/index.js
+++ b/scores/adsr/index.js
@@ -447,9 +447,9 @@ VS.score.preroll = 3000;
 
 // scoreSettings.preroll.value = (VS.score.preroll * 0.001);
 
-VS.score.playCallback = function() {
+VS.score.hooks.add('play', function() {
     VS.score.schedule(VS.score.preroll - 3000, cueBlink);
-};
+});
 
 function scrollCallback() {
     var pointer = VS.score.pointer;
@@ -460,8 +460,9 @@ function scrollCallback() {
 
     cueIndicator.cancel();
 }
-VS.score.pauseCallback = scrollCallback;
-VS.score.stopCallback = scrollCallback;
+
+VS.score.hooks.add('pause', scrollCallback);
+VS.score.hooks.add('stop', scrollCallback);
 VS.control.hooks.add('step', scrollCallback);
 
 function resize() {

--- a/scores/adsr/index.js
+++ b/scores/adsr/index.js
@@ -462,7 +462,7 @@ function scrollCallback() {
 }
 VS.score.pauseCallback = scrollCallback;
 VS.score.stopCallback = scrollCallback;
-VS.control.stepCallback.push(scrollCallback);
+VS.control.hooks.add('step', scrollCallback);
 
 function resize() {
     // TODO pause score if playing

--- a/scores/decision-tree/cells/_controls.js
+++ b/scores/decision-tree/cells/_controls.js
@@ -2,8 +2,8 @@
  * Score callbacks
  * Choices should be cleared so new choices can be loaded and selected on play
  */
-VS.score.pauseCallback = clearChoices;
-VS.score.stopCallback = clearChoices;
+VS.score.hooks.add('pause', clearChoices);
+VS.score.hooks.add('stop', clearChoices);
 
 /**
  * Keyboard

--- a/scores/dirge-march/index.js
+++ b/scores/dirge-march/index.js
@@ -449,5 +449,5 @@ d3.select(window).on('load', function() {
 
     VS.control.stopCallback = controlCallback;
     VS.control.pauseCallback = controlCallback
-    VS.control.stepCallback.push(controlCallback);
+    VS.control.hooks.add('step', controlCallback);
 })();

--- a/scores/dirge-march/index.js
+++ b/scores/dirge-march/index.js
@@ -441,10 +441,13 @@ d3.select(window).on('load', function() {
 /**
  * Score controls
  */
-VS.control.stopCallback = function() {
-    update(0, true);
-};
-VS.control.pauseCallback = VS.control.stepCallback = function() {
-    // console.log('mm. ' + (VS.score.pointer + 1));
-    update(VS.score.pointer, true);
-};
+(function() {
+    var controlCallback = function() {
+        // console.log('mm. ' + (VS.score.pointer + 1));
+        update(VS.score.pointer, true);
+    }
+
+    VS.control.stopCallback = controlCallback;
+    VS.control.pauseCallback = controlCallback
+    VS.control.stepCallback.push(controlCallback);
+})();

--- a/scores/dirge-march/index.js
+++ b/scores/dirge-march/index.js
@@ -447,7 +447,7 @@ d3.select(window).on('load', function() {
         update(VS.score.pointer, true);
     }
 
-    VS.control.stopCallback = controlCallback;
-    VS.control.pauseCallback = controlCallback
+    VS.control.hooks.add('stop', controlCallback);
+    VS.control.hooks.add('pause', controlCallback);
     VS.control.hooks.add('step', controlCallback);
 })();

--- a/scores/glob/_controls.js
+++ b/scores/glob/_controls.js
@@ -8,6 +8,6 @@
         }
     };
 
-    VS.score.stopCallback = controlCallback;
+    VS.score.hooks.add('stop', controlCallback);
     VS.control.hooks.add('step', controlCallback);
 })();

--- a/scores/glob/_controls.js
+++ b/scores/glob/_controls.js
@@ -1,8 +1,13 @@
-VS.control.stepCallback = VS.score.stopCallback = function() {
-    var pointer = VS.score.pointer;
-    var fn = VS.score.funcAt(pointer);
+(function() {
+    var controlCallback = function() {
+        var pointer = VS.score.pointer;
+        var fn = VS.score.funcAt(pointer);
 
-    if (typeof fn === 'function') {
-        update(transitionTime.short, score[VS.score.pointer]);
-    }
-};
+        if (typeof fn === 'function') {
+            update(transitionTime.short, score[VS.score.pointer]);
+        }
+    };
+
+    VS.score.stopCallback = controlCallback;
+    VS.control.stepCallback.push(controlCallback);
+})();

--- a/scores/glob/_controls.js
+++ b/scores/glob/_controls.js
@@ -9,5 +9,5 @@
     };
 
     VS.score.stopCallback = controlCallback;
-    VS.control.stepCallback.push(controlCallback);
+    VS.control.hooks.add('step', controlCallback);
 })();

--- a/scores/globject/index.js
+++ b/scores/globject/index.js
@@ -143,4 +143,4 @@ update(0);
  * Score controls
  */
 VS.control.stopCallback = function() { update(0); };
-VS.control.stepCallback = function() { update(VS.score.pointer); };
+VS.control.stepCallback.push(function() { update(VS.score.pointer); });

--- a/scores/globject/index.js
+++ b/scores/globject/index.js
@@ -142,5 +142,5 @@ update(0);
 /**
  * Score controls
  */
-VS.control.stopCallback = function() { update(0); };
+VS.control.hooks.add('stop', function() { update(0); });
 VS.control.hooks.add('step', function() { update(VS.score.pointer); });

--- a/scores/globject/index.js
+++ b/scores/globject/index.js
@@ -143,4 +143,4 @@ update(0);
  * Score controls
  */
 VS.control.stopCallback = function() { update(0); };
-VS.control.stepCallback.push(function() { update(VS.score.pointer); });
+VS.control.hooks.add('step', function() { update(VS.score.pointer); });

--- a/scores/storyboard/cards/index.js
+++ b/scores/storyboard/cards/index.js
@@ -156,5 +156,5 @@ function scoreControlCallback() {
 }
 
 VS.control.hooks.add('step', scoreControlCallback);
-VS.score.stopCallback = scoreControlCallback;
-VS.score.pauseCallback = scoreControlCallback;
+VS.control.hooks.add('pause', scoreControlCallback);
+VS.score.hooks.add('stop', scoreControlCallback);

--- a/scores/storyboard/cards/index.js
+++ b/scores/storyboard/cards/index.js
@@ -155,6 +155,6 @@ function scoreControlCallback() {
     goToCard();
 }
 
-VS.control.stepCallback = scoreControlCallback;
+VS.control.stepCallback.push(scoreControlCallback);
 VS.score.stopCallback = scoreControlCallback;
 VS.score.pauseCallback = scoreControlCallback;

--- a/scores/storyboard/cards/index.js
+++ b/scores/storyboard/cards/index.js
@@ -155,6 +155,6 @@ function scoreControlCallback() {
     goToCard();
 }
 
-VS.control.stepCallback.push(scoreControlCallback);
+VS.control.hooks.add('step', scoreControlCallback);
 VS.score.stopCallback = scoreControlCallback;
 VS.score.pauseCallback = scoreControlCallback;

--- a/scores/storyboard/prelude/index.js
+++ b/scores/storyboard/prelude/index.js
@@ -304,7 +304,7 @@ VS.score.pauseCallback = VS.score.stopCallback = function() {
     goToCard();
 };
 
-VS.control.stepCallback.push(goToCard);
+VS.control.hooks.add('step', goToCard);
 
 /**
  * Resize

--- a/scores/storyboard/prelude/index.js
+++ b/scores/storyboard/prelude/index.js
@@ -304,7 +304,7 @@ VS.score.pauseCallback = VS.score.stopCallback = function() {
     goToCard();
 };
 
-VS.control.stepCallback = goToCard;
+VS.control.stepCallback.push(goToCard);
 
 /**
  * Resize

--- a/scores/storyboard/prelude/index.js
+++ b/scores/storyboard/prelude/index.js
@@ -291,18 +291,20 @@ addEvent();
 
 VS.score.preroll = score.cueDuration; // cardTransTime;
 
-VS.score.playCallback = function() {
+VS.control.hooks.add('play', function() {
     goToCard(VS.score.pointer - 1, 'play');
     // VS.score.schedule(VS.score.preroll - score.cueDuration, cueBlink);
     VS.score.schedule(VS.score.preroll - cues[VS.score.pointer].duration(), cueBlink, VS.score.pointer - 1);
-};
+});
 
-VS.score.pauseCallback = VS.score.stopCallback = function() {
+function cancelAndGoToCard() {
     cueCancelAll();
     d3.selectAll('.cue').style('opacity', 0);
     fadePenultimateScene(false, 0);
     goToCard();
-};
+}
+VS.control.hooks.add('pause', cancelAndGoToCard);
+VS.control.hooks.add('stop', cancelAndGoToCard);
 
 VS.control.hooks.add('step', goToCard);
 

--- a/scores/time-control/index.js
+++ b/scores/time-control/index.js
@@ -93,4 +93,4 @@ VS.control.hooks.add('step', function() {
     }
 });
 
-VS.score.stopCallback = resetSpans;
+VS.score.hooks.add('stop', resetSpans);

--- a/scores/time-control/index.js
+++ b/scores/time-control/index.js
@@ -79,7 +79,7 @@ function resetSpans() {
 }
 
 // Activate all spans up to pointer
-VS.control.stepCallback = function() {
+VS.control.stepCallback.push(function() {
     resetSpans();
 
     var index = VS.score.pointer;
@@ -91,6 +91,6 @@ VS.control.stepCallback = function() {
         fn = VS.score.funcAt(i);
         fn.apply(null, params);
     }
-};
+});
 
 VS.score.stopCallback = resetSpans;

--- a/scores/time-control/index.js
+++ b/scores/time-control/index.js
@@ -79,7 +79,7 @@ function resetSpans() {
 }
 
 // Activate all spans up to pointer
-VS.control.stepCallback.push(function() {
+VS.control.hooks.add('step', function() {
     resetSpans();
 
     var index = VS.score.pointer;

--- a/scores/topographies-ii/walk-reveal/index.js
+++ b/scores/topographies-ii/walk-reveal/index.js
@@ -357,7 +357,7 @@ VS.control.hooks.add('step', function() {
     }
 });
 
-VS.score.stopCallback = forgetAll;
+VS.control.hooks.add('stop', forgetAll);
 
 /**
  * Resize

--- a/scores/topographies-ii/walk-reveal/index.js
+++ b/scores/topographies-ii/walk-reveal/index.js
@@ -348,7 +348,7 @@ function toggleInstructions(duration, toggle) {
 /**
  * Controls
  */
-VS.control.stepCallback.push(function() {
+VS.control.hooks.add('step', function() {
     var pointer = VS.score.pointer;
     var fn = VS.score.funcAt(pointer);
 

--- a/scores/topographies-ii/walk-reveal/index.js
+++ b/scores/topographies-ii/walk-reveal/index.js
@@ -348,14 +348,14 @@ function toggleInstructions(duration, toggle) {
 /**
  * Controls
  */
-VS.control.stepCallback = function() {
+VS.control.stepCallback.push(function() {
     var pointer = VS.score.pointer;
     var fn = VS.score.funcAt(pointer);
 
     if (typeof fn === 'function') {
         fn(150);
     }
-};
+});
 
 VS.score.stopCallback = forgetAll;
 

--- a/scores/trashfire/index.js
+++ b/scores/trashfire/index.js
@@ -37,12 +37,12 @@ var layout = {
 {% include_relative _scrape-drone.js %}
 {% include_relative _score.js %}
 
-VS.score.stopCallback = function() {
+VS.score.hooks.add('stop', function() {
     trash = [];
     TrashFire.noiseLayer.remove(0); // calls updateTrash();
     TrashFire.scrapeDrone.hide(0);
     dumpsterShake();
-};
+});
 
 /**
  * Resize

--- a/scores/tutorial/index.js
+++ b/scores/tutorial/index.js
@@ -118,6 +118,6 @@ VS.control.hooks.add('step', function() {
     VS.score.funcAt(VS.score.pointer)();
 });
 
-VS.score.stopCallback = function() {
-    message.innerHTML = initialMessage;
-};
+VS.score.hooks.add('stop', function() {
+   message.innerHTML = initialMessage;
+});

--- a/scores/tutorial/index.js
+++ b/scores/tutorial/index.js
@@ -114,9 +114,9 @@ addEvent(function() {
 /**
  *
  */
-VS.control.stepCallback = function() {
+VS.control.stepCallback.push(function() {
     VS.score.funcAt(VS.score.pointer)();
-};
+});
 
 VS.score.stopCallback = function() {
     message.innerHTML = initialMessage;

--- a/scores/tutorial/index.js
+++ b/scores/tutorial/index.js
@@ -114,7 +114,7 @@ addEvent(function() {
 /**
  *
  */
-VS.control.stepCallback.push(function() {
+VS.control.hooks.add('step', function() {
     VS.score.funcAt(VS.score.pointer)();
 });
 


### PR DESCRIPTION
- [x] replace control callbacks with hooks
- [x] replace score callbacks with hooks
- [ ] replace websockets callbacks with hooks
- [ ] rename/refactor functions in score referred to as "callbacks"
- [ ] Rethink the use of score vs. control hooks (only a score 'stop' hook seems to be relevant) and refactor accordingly. Consider the current use of score hooks as used with websockets.
