### PR TITLE
Run tests after loading DOM from file and window has loaded

### DIFF
--- a/_jekyll/includes/score/scripts.html
+++ b/_jekyll/includes/score/scripts.html
@@ -1,7 +1,7 @@
 {% if jekyll.environment == "offline" %}
     <script src="{{ '/js/lib/d3.v4.min.js' | prepend: assets_url }}" charset="utf-8"></script>
 {% else %}
-    <script src="//d3js.org/d3.v4.min.js" charset="utf-8"></script>
+    <script src="https://d3js.org/d3.v4.min.js" charset="utf-8"></script>
 {% endif %}
 
 <script src="{{ '/js/vectorscores.js' | prepend: assets_url }}" charset="utf-8"></script>

--- a/_jekyll/layouts/score.html
+++ b/_jekyll/layouts/score.html
@@ -1,7 +1,8 @@
 ---
 layout: compress
 ---
-{% assign assets_url = site.assetsurl | prepend: site.baseurl %}
+{% assign dirs_to_root = page.url | split: '/' | size | minus: 1 %}
+{% capture assets_url %}{% for i in (1..dirs_to_root) %}../{% endfor %}assets{% endcapture %}
 
 <!DOCTYPE html>
 <html>

--- a/assets/js/_tests/helpers.math.js
+++ b/assets/js/_tests/helpers.math.js
@@ -1,8 +1,6 @@
 const path = require('path')
-const { test, setupDOM } = require(path.resolve('.', 'bin/js/tape-setup'))
-setupDOM('_site/scores/tutorial/index.html')
+const { test, getWindowFromFile } = require(path.resolve('.', 'bin/js/tape-setup'))
 
-const VS = require(path.resolve('.', '_site/assets/js/vectorscores.js'))
 const sampleSize = 1 // 5000000
 
 const reportDistribution = function({ expected, actual }) {
@@ -11,7 +9,18 @@ const reportDistribution = function({ expected, actual }) {
     console.log('actual:\t', actual)
 }
 
+let window
+
+test('setup', t => {
+    getWindowFromFile('_site/scores/tutorial/index.html', loadedWindow => {
+        window = loadedWindow
+        t.end()
+    })
+})
+
 test('VS#getRandExcl', { skip: sampleSize < 999 }, t => {
+    const VS = window.VS
+
     const min = 0
     const max = 1
     let results = []
@@ -30,6 +39,8 @@ test('VS#getRandExcl', { skip: sampleSize < 999 }, t => {
 })
 
 test('VS#getRandIntIncl', { skip: sampleSize < 999 }, t => {
+    const VS = window.VS
+
     const min = 1
     const max = 5
     let results = []
@@ -52,6 +63,8 @@ test('VS#getRandIntIncl', { skip: sampleSize < 999 }, t => {
 })
 
 test('VS#getItem', { skip: sampleSize < 999 }, t => {
+    const VS = window.VS
+
     const items = ['a', 'b', 'c', 'd', 'e']
     const count = [0, 0, 0, 0, 0]
     let results = []
@@ -88,6 +101,8 @@ test('VS#getItem', { skip: sampleSize < 999 }, t => {
 })
 
 test('VS#getWeightedItem', { skip: sampleSize < 999 }, t => {
+    const VS = window.VS
+
     const items = ['a', 'b', 'c', 'd', 'e']
     const weights = [0.5, 0.25, 0.125, 0.0625, 0.0625]
     const count = [0, 0, 0, 0, 0]
@@ -123,6 +138,8 @@ test('VS#getWeightedItem', { skip: sampleSize < 999 }, t => {
 })
 
 test('VS#clamp', t => {
+    const VS = window.VS
+
     t.equal(VS.clamp(11, 0, 5), 5, 'return max when value is greater than max')
     t.equal(VS.clamp(-11, 0, 5), 0, 'return min when value is less than min')
     t.equal(VS.clamp(2.5, 0, 5), 2.5, 'return value when value is between min and max')
@@ -131,6 +148,8 @@ test('VS#clamp', t => {
 })
 
 test('VS#normalize', t => {
+    const VS = window.VS
+
     const min = -5
     const max = 5
 
@@ -142,6 +161,8 @@ test('VS#normalize', t => {
 })
 
 test('VS#mod', t => {
+    const VS = window.VS
+
     t.equal(VS.mod(6, 12), 6, 'return 6 when 6 mod 12')
     t.equal(VS.mod(13, 12), 1, 'return 1 when 13 mod 12')
 

--- a/assets/js/_tests/helpers.util.js
+++ b/assets/js/_tests/helpers.util.js
@@ -1,10 +1,17 @@
 const path = require('path')
-const { test, setupDOM } = require(path.resolve('.', 'bin/js/tape-setup'))
-setupDOM('_site/scores/tutorial/index.html')
+const { test, getWindowFromFile } = require(path.resolve('.', 'bin/js/tape-setup'))
 
-const VS = require(path.resolve('.', '_site/assets/js/vectorscores.js'))
+let window
+
+test('setup', t => {
+    getWindowFromFile('_site/scores/tutorial/index.html', loadedWindow => {
+        window = loadedWindow
+        t.end()
+    })
+})
 
 test('VS#getQueryString', t => {
+    const VS = window.VS
     const url = 'http://localhost:4000/vectorscores/scores/adsr/?parts=4&showall=on'
 
     t.equal(VS.getQueryString('parts', url), '4', 'return value as string given query parameter that exists in url')
@@ -14,6 +21,7 @@ test('VS#getQueryString', t => {
 })
 
 test('VS#makeQueryString', t => {
+    const VS = window.VS
     t.equal(VS.makeQueryString({ a: '1' }), 'a=1', 'return query string')
     t.equal(VS.makeQueryString({ a: '1', b: '2' }), 'a=1&b=2', 'return query string joined by \'&\'')
 
@@ -21,6 +29,7 @@ test('VS#makeQueryString', t => {
 })
 
 test('VS#constant', t => {
+    const VS = window.VS
     const value = 5
     const c = VS.constant(value)
 
@@ -29,3 +38,4 @@ test('VS#constant', t => {
 
     t.end()
 })
+// }

--- a/assets/js/_tests/helpers.util.js
+++ b/assets/js/_tests/helpers.util.js
@@ -38,4 +38,3 @@ test('VS#constant', t => {
 
     t.end()
 })
-// }

--- a/assets/js/_tests/hooks.js
+++ b/assets/js/_tests/hooks.js
@@ -1,30 +1,31 @@
 const path = require('path')
-const { test, setupDOM } = require(path.resolve('.', 'bin/js/tape-setup'))
-setupDOM('_site/scores/tutorial/index.html')
-
-const VS = require(path.resolve('.', '_site/assets/js/vectorscores.js'))
+const { test, getWindowFromFile } = require(path.resolve('.', 'bin/js/tape-setup'))
 
 test('VS#createHooks', t => {
-    const hooks = new VS.createHooks(['play'])
+    getWindowFromFile('_site/scores/tutorial/index.html', window => {
+        const VS = window.VS
 
-    const expected = {
-        a: 2,
-        b: 4,
-        c: 6
-    }
-    let actual = {}
+        const hooks = new VS.createHooks(['play'])
 
-    hooks.add('play', () => { actual.a = 2 })
-    hooks.add('play', () => { actual.b = 4 })
-    hooks.add('play', () => { actual.c = 6 })
+        const expected = {
+            a: 2,
+            b: 4,
+            c: 6
+        }
+        let actual = {}
 
-    hooks.trigger('play')
+        hooks.add('play', () => { actual.a = 2 })
+        hooks.add('play', () => { actual.b = 4 })
+        hooks.add('play', () => { actual.c = 6 })
 
-    t.deepEqual(actual, expected, 'should execute all registered functions')
+        hooks.trigger('play')
 
-    t.throws(() => {
-        hooks.add('test', () => {})
-    }, 'should throw an error when adding an unregistered hook')
+        t.deepEqual(actual, expected, 'should execute all registered functions')
 
-    t.end()
+        t.throws(() => {
+            hooks.add('test', () => {})
+        }, 'should throw an error when adding an unregistered hook')
+
+        t.end()
+    })
 })

--- a/assets/js/_tests/score.options.js
+++ b/assets/js/_tests/score.options.js
@@ -1,54 +1,47 @@
 const path = require('path')
-const { test, setupDOM } = require(path.resolve('.', 'bin/js/tape-setup'))
-setupDOM('_site/scores/tutorial/index.html')
+const { test, getWindowFromFile } = require(path.resolve('.', 'bin/js/tape-setup'))
 
-const vsPath = path.resolve('.', '_site/assets/js/vectorscores.js')
-
-// Clear require cache so VS (and VS.score.options) do not carry over between tests
-function clearVSFromCache() {
-    delete require.cache[vsPath]
-}
-
+const htmlPath = '_site/scores/tutorial/index.html'
 const url = 'http://localhost:4000/vectorscores/scores/adsr/?parts=4&showall=on'
 
 const MockControl = function() {}
 MockControl.prototype.set = function() {}
 
 test('VS.score.options', t => {
-    const VS = require(vsPath)
+    getWindowFromFile(htmlPath, window => {
+        const VS = window.VS
 
-    VS.score.options.add('parts', '2', new MockControl())
-    const options = VS.score.options.setFromQueryString(url)
+        VS.score.options.add('parts', '2', new MockControl())
+        const options = VS.score.options.setFromQueryString(url)
 
-    t.deepEqual(options, { parts: '4' }, 'should set option from query string')
+        t.deepEqual(options, { parts: '4' }, 'should set option from query string')
 
-    clearVSFromCache()
-
-    t.end()
+        t.end()
+    })
 })
 
 test('VS.score.options', t => {
-    const VS = require(vsPath)
+    getWindowFromFile(htmlPath, window => {
+        const VS = window.VS
 
-    VS.score.options.add('test', 'yes', new MockControl())
-    const options = VS.score.options.setFromQueryString(url)
+        VS.score.options.add('test', 'yes', new MockControl())
+        const options = VS.score.options.setFromQueryString(url)
 
-    t.deepEqual(options, { test: 'yes' }, 'should use default if parameter is not in query string')
+        t.deepEqual(options, { test: 'yes' }, 'should use default if parameter is not in query string')
 
-    clearVSFromCache()
-
-    t.end()
+        t.end()
+    })
 })
 
 test('VS.score.options', t => {
-    const VS = require(vsPath)
+    getWindowFromFile(htmlPath, window => {
+        const VS = window.VS
 
-    VS.score.options.add('parts', null, new MockControl())
-    const options = VS.score.options.setFromQueryString(url)
+        VS.score.options.add('parts', null, new MockControl())
+        const options = VS.score.options.setFromQueryString(url)
 
-    t.deepEqual(options, { parts: '4' }, 'should set option from query string with a default of \'null\'')
+        t.deepEqual(options, { parts: '4' }, 'should set option from query string with a default of \'null\'')
 
-    clearVSFromCache()
-
-    t.end()
+        t.end()
+    })
 })

--- a/assets/js/vectorscores.js
+++ b/assets/js/vectorscores.js
@@ -12,7 +12,3 @@ var VS = {};
 {% include_relative _score.options.js %}
 {% include_relative _controls.js %}
 {% include_relative _modals.js %}
-
-if (typeof module !== 'undefined' && module.exports) {
-    module.exports = VS;
-}

--- a/assets/modules/cue/_tests/blink.js
+++ b/assets/modules/cue/_tests/blink.js
@@ -1,0 +1,17 @@
+const path = require('path')
+const { test, getWindowFromFile } = require(path.resolve('.', 'bin/js/tape-setup'))
+
+test('cueBlink', t => {
+    getWindowFromFile('_site/assets/modules/cue/index.html', window => {
+        const { d3, document, VS } = window
+
+        let indicator = d3.select(document).select('svg').append('circle')
+
+        let cue = VS.cueBlink(indicator)
+            .beats(2)
+
+        t.equal(cue.beats(), 2, 'should get and set number of beats via beats method')
+
+        t.end()
+    })
+})

--- a/bin/js/tape-setup.js
+++ b/bin/js/tape-setup.js
@@ -1,21 +1,26 @@
+const path = require('path')
+const { JSDOM } = require('jsdom')
+
 /**
- * Helper for intializing tests and JSDOM
+ * Create DOM from file and call function
+ * with window object when document is loaded
  */
-function setupDOM(filePath) {
-    const path = require('path')
-    const fs = require('fs')
+function getWindowFromFile(filePath, onLoad) {
+    const options = {
+        resources: 'usable',
+        runScripts: 'dangerously'
+    }
 
-    const JSDOM = require('jsdom').JSDOM
-    const html = fs.readFileSync(path.resolve('.', filePath), 'utf8')
-    const DOM = new JSDOM(html)
+    JSDOM.fromFile(path.resolve('.', filePath), options).then(dom => {
+        const window = dom.window
 
-    global.window = DOM.window
-    global.document = DOM.window.document
-
-    return DOM
+        window.addEventListener('load', () => {
+            onLoad(window)
+        })
+    })
 }
 
 module.exports = {
     test: require('tape'),
-    setupDOM
+    getWindowFromFile
 }

--- a/scores/adsr/_tests/options.js
+++ b/scores/adsr/_tests/options.js
@@ -1,11 +1,12 @@
 const path = require('path')
-const { test, setupDOM } = require(path.resolve('.', 'bin/js/tape-setup'))
-setupDOM('_site/scores/adsr/index.html')
+const { test, getWindowFromFile } = require(path.resolve('.', 'bin/js/tape-setup'))
 
 test('ad;sr', t => {
-    const optionsButton = document.getElementById('score-options-open')
+    getWindowFromFile('_site/scores/adsr/index.html', window => {
+        const optionsButton = window.document.getElementById('score-options-open')
 
-    t.true(optionsButton instanceof window.HTMLElement, 'should have a #score-options-open button')
+        t.true(optionsButton instanceof window.HTMLElement, 'should have a #score-options-open button')
 
-    t.end()
+        t.end()
+    })
 })


### PR DESCRIPTION
- refactor DOM test setup
- use relative paths in scores for test support
- remove the need for test globals (#91)